### PR TITLE
[feat] calendar 구현

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -47,6 +47,7 @@ const RAW_RUNTIME_STATE =
           ["json-server", "npm:1.0.0-beta.0"],\
           ["prettier", "npm:3.2.5"],\
           ["react", "npm:18.3.1"],\
+          ["react-day-picker", "virtual:efe1763f48a1a789144d819afe97cffa3346ee2f464e9c7652b26290d830b9a3e90e5496c21f0ef2e7f8a66e53bc8a549d7f1867c7213cd5156faefbd19468ef#npm:8.10.1"],\
           ["react-dom", "virtual:efe1763f48a1a789144d819afe97cffa3346ee2f464e9c7652b26290d830b9a3e90e5496c21f0ef2e7f8a66e53bc8a549d7f1867c7213cd5156faefbd19468ef#npm:18.3.1"],\
           ["react-scripts", "virtual:efe1763f48a1a789144d819afe97cffa3346ee2f464e9c7652b26290d830b9a3e90e5496c21f0ef2e7f8a66e53bc8a549d7f1867c7213cd5156faefbd19468ef#npm:5.0.1"],\
           ["sass", "npm:1.77.2"],\
@@ -13674,6 +13675,7 @@ const RAW_RUNTIME_STATE =
           ["json-server", "npm:1.0.0-beta.0"],\
           ["prettier", "npm:3.2.5"],\
           ["react", "npm:18.3.1"],\
+          ["react-day-picker", "virtual:efe1763f48a1a789144d819afe97cffa3346ee2f464e9c7652b26290d830b9a3e90e5496c21f0ef2e7f8a66e53bc8a549d7f1867c7213cd5156faefbd19468ef#npm:8.10.1"],\
           ["react-dom", "virtual:efe1763f48a1a789144d819afe97cffa3346ee2f464e9c7652b26290d830b9a3e90e5496c21f0ef2e7f8a66e53bc8a549d7f1867c7213cd5156faefbd19468ef#npm:18.3.1"],\
           ["react-scripts", "virtual:efe1763f48a1a789144d819afe97cffa3346ee2f464e9c7652b26290d830b9a3e90e5496c21f0ef2e7f8a66e53bc8a549d7f1867c7213cd5156faefbd19468ef#npm:5.0.1"],\
           ["sass", "npm:1.77.2"],\
@@ -15807,6 +15809,32 @@ const RAW_RUNTIME_STATE =
           ["raf", "npm:3.4.1"],\
           ["regenerator-runtime", "npm:0.13.11"],\
           ["whatwg-fetch", "npm:3.6.20"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["react-day-picker", [\
+      ["npm:8.10.1", {\
+        "packageLocation": "../../../AppData/Local/Yarn/Berry/cache/react-day-picker-npm-8.10.1-708bfe7c0e-10c0.zip/node_modules/react-day-picker/",\
+        "packageDependencies": [\
+          ["react-day-picker", "npm:8.10.1"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:efe1763f48a1a789144d819afe97cffa3346ee2f464e9c7652b26290d830b9a3e90e5496c21f0ef2e7f8a66e53bc8a549d7f1867c7213cd5156faefbd19468ef#npm:8.10.1", {\
+        "packageLocation": "./.yarn/__virtual__/react-day-picker-virtual-0a0a70a9b7/4/AppData/Local/Yarn/Berry/cache/react-day-picker-npm-8.10.1-708bfe7c0e-10c0.zip/node_modules/react-day-picker/",\
+        "packageDependencies": [\
+          ["react-day-picker", "virtual:efe1763f48a1a789144d819afe97cffa3346ee2f464e9c7652b26290d830b9a3e90e5496c21f0ef2e7f8a66e53bc8a549d7f1867c7213cd5156faefbd19468ef#npm:8.10.1"],\
+          ["@types/date-fns", null],\
+          ["@types/react", "npm:18.3.3"],\
+          ["date-fns", "npm:3.6.0"],\
+          ["react", "npm:18.3.1"]\
+        ],\
+        "packagePeers": [\
+          "@types/date-fns",\
+          "@types/react",\
+          "date-fns",\
+          "react"\
         ],\
         "linkType": "HARD"\
       }]\

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "classnames": "^2.5.1",
     "date-fns": "^3.6.0",
     "react": "^18.3.1",
+    "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-scripts": "5.0.1",
     "sass": "^1.77.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Intro from '@components/sections/Intro'
 
 import { Wedding } from '@models/wedding'
 import Invitation from './components/sections/Invitation'
+import Calendar from './components/sections/Calendar'
 
 const cx = classNames.bind(styles)
 
@@ -79,6 +80,7 @@ function App() {
       />
       <Invitation message={invitation} />
       <ImageGallery images={galleryImages} />
+      <Calendar date={date} />
       {JSON.stringify(wedding)}
     </div>
   )

--- a/src/components/sections/Calendar.module.scss
+++ b/src/components/sections/Calendar.module.scss
@@ -1,0 +1,23 @@
+.wrap-header {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin: 30px 0;
+
+    .txt-date {
+        font-size: 18px;
+        font-weight: bold;
+        margin-bottom: 12px;
+    }
+
+    .txt-time {
+        font-size: 15px;
+        font-weight: 500;
+    }
+}
+
+.wrap-calendar {
+    display: flex;
+    justify-content: center;
+}

--- a/src/components/sections/Calendar.tsx
+++ b/src/components/sections/Calendar.tsx
@@ -1,0 +1,60 @@
+import { format, parseISO } from 'date-fns'
+import { ko } from 'date-fns/locale'
+import classNames from 'classnames/bind'
+import styles from './Calendar.module.scss'
+import Section from '@shared/Section'
+
+import { DayPicker } from 'react-day-picker'
+import 'react-day-picker/dist/style.css'
+
+const cx = classNames.bind(styles)
+
+const css = `
+    .rdp-caption{
+        display: none;
+    }
+    .rdp-cell{
+        cursor: default;
+    }
+    .rdp-header-cell {
+        font-weight: 500;
+        font-size: 14px;
+        font-weight: bold;
+    }
+    .rdp-day_selected {
+        background-color: var(--red);
+        font-weight: bold;
+        color: #fff;
+    }
+    .rdp-day_selected:hover {
+        background-color: var(--red);
+    }
+`
+
+export default function Calendar({ date }: { date: string }) {
+  const weddingDate = parseISO(date)
+  return (
+    <Section
+      title={
+        <div className={cx('wrap-header')}>
+          <span className={cx('txt-date')}>
+            {format(weddingDate, 'yyyy.MM.dd')}
+          </span>
+          <span className={cx('txt-time')}>
+            {format(weddingDate, 'aaa h시 eeee', { locale: ko })}
+          </span>
+        </div>
+      }
+    >
+      <div className={cx('wrap-calendar')}>
+        <style>{css}</style>
+        <DayPicker
+          locale={ko}
+          month={weddingDate}
+          selected={weddingDate}
+          formatters={{ formatCaption: () => '' }}
+        />
+      </div>
+    </Section>
+  )
+}

--- a/src/components/shared/Section.tsx
+++ b/src/components/shared/Section.tsx
@@ -10,7 +10,7 @@ export default function Section({
 }: {
   children: React.ReactNode
   className?: string
-  title?: string
+  title?: React.ReactNode
 }) {
   return (
     <section className={cx(['container', className])}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10207,6 +10207,7 @@ __metadata:
     json-server: "npm:^1.0.0-beta.0"
     prettier: "npm:^3.2.5"
     react: "npm:^18.3.1"
+    react-day-picker: "npm:^8.10.1"
     react-dom: "npm:^18.3.1"
     react-scripts: "npm:5.0.1"
     sass: "npm:^1.77.2"
@@ -11428,6 +11429,16 @@ __metadata:
     regenerator-runtime: "npm:^0.13.9"
     whatwg-fetch: "npm:^3.6.2"
   checksum: 10c0/7079c81717f4707d078943ab507771c3e80333e6c2c80c8d9a02e4a5661974e9bb196aea9f56336f559214a23f495c5f3907937d13a070e701019ae7a9d53c26
+  languageName: node
+  linkType: hard
+
+"react-day-picker@npm:^8.10.1":
+  version: 8.10.1
+  resolution: "react-day-picker@npm:8.10.1"
+  peerDependencies:
+    date-fns: ^2.28.0 || ^3.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 10c0/a0ff28c4b61b3882e6a825b19e5679e2fdf3256cf1be8eb0a0c028949815c1ae5a6561474c2c19d231c010c8e0e0b654d3a322610881e0655abca05a2e03d9df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- 결혼식 일정을 calendar Component로 구현
  - react-day-picker 라이브러리를 이용하여 캘린더 렌더링
  - 스타일을 override하여 구현
  - section Component에 title을 reactNode로 넘겨주도록 구현