### PR TITLE
[feat] modal 참석자 수 api 연동

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <div id="root-portal"></div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,8 @@ import Calendar from '@components/sections/Calendar'
 import Map from '@components/sections/Map'
 import Contact from '@components/sections/Contact'
 import Share from '@components/sections/Share'
+import Modal from '@shared/Modal'
+import AttendCountModal from './components/AttendCountModal'
 
 const cx = classNames.bind(styles)
 
@@ -86,6 +88,7 @@ function App() {
       <Map location={location} />
       <Contact groom={groom} bride={bride} />
       <Share gromeName={groom.name} brideName={bride.name} date={date} />
+      <AttendCountModal wedding={wedding} />
     </div>
   )
 }

--- a/src/components/AttendCountModal/index.tsx
+++ b/src/components/AttendCountModal/index.tsx
@@ -1,0 +1,55 @@
+import { useModalContext } from '@/contexts/ModalContext'
+import { Wedding } from '@/models/wedding'
+import { useEffect, useRef } from 'react'
+
+export default function AttendCountModal({ wedding }: { wedding: Wedding }) {
+  const { open, close } = useModalContext()
+
+  const $input = useRef<HTMLInputElement>(null)
+
+  const haveSeenModal = localStorage.getItem('@have-seen-modal')
+
+  useEffect(() => {
+    if (haveSeenModal === 'true') {
+      return
+    }
+
+    open({
+      title: `현재 참석자:${wedding.attendCount} 명`,
+      body: (
+        <div>
+          <input
+            ref={$input}
+            placeholder="참석 가능한 인원을 추가해주세요"
+            style={{ width: '100%' }}
+            type="number"
+          />
+        </div>
+      ),
+      onLeftButtonClick: () => {
+        localStorage.setItem('@have-seen-modal', 'true')
+        close()
+      },
+      onRightButtonClick: async () => {
+        if ($input == null) {
+          return
+        }
+        fetch('http://localhost:8888/wedding', {
+          method: 'PUT',
+          body: JSON.stringify({
+            ...wedding,
+            attendCount: wedding.attendCount + Number($input.current?.value),
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        })
+
+        localStorage.setItem('@have-seen-modal', 'true')
+        close()
+      },
+    })
+  }, [])
+
+  return null
+}

--- a/src/components/shared/Modal.tsx
+++ b/src/components/shared/Modal.tsx
@@ -6,7 +6,7 @@ const cx = classNames.bind(styles)
 
 interface ModalProps {
   open: boolean
-  title: string
+  title?: string
   body: React.ReactNode
   rightButtonLabel?: string
   onRightButtonClick: () => void
@@ -18,8 +18,8 @@ export default function Modal({
   open,
   title,
   body,
-  rightButtonLabel = '닫기',
-  leftButtonLabel = '확인',
+  rightButtonLabel = '확인',
+  leftButtonLabel = '닫기',
   onRightButtonClick,
   onLeftButtonClick,
 }: ModalProps) {

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -1,0 +1,59 @@
+import { createContext, ComponentProps, useContext, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+import Modal from '@shared/Modal'
+
+type ModalProps = ComponentProps<typeof Modal>
+type ModalOptions = Omit<ModalProps, 'open'>
+
+interface ModalContextValue {
+  open: (options: ModalOptions) => void
+  close: () => void
+}
+
+const Context = createContext<ModalContextValue | undefined>(undefined)
+
+const defaultValues: ModalProps = {
+  open: false,
+  body: null,
+  onRightButtonClick: () => {},
+  onLeftButtonClick: () => {},
+}
+
+export function ModalContext({ children }: { children: React.ReactNode }) {
+  const [modalState, setModalState] = useState<ModalProps>(defaultValues)
+
+  const $portal_root = document.getElementById('root-portal')
+
+  const open = (options: ModalOptions) => {
+    setModalState({ ...options, open: true })
+  }
+
+  const close = () => {
+    setModalState(defaultValues)
+  }
+
+  const values = {
+    open,
+    close,
+  }
+
+  return (
+    <Context.Provider value={values}>
+      {children}
+      {$portal_root != null
+        ? createPortal(<Modal {...modalState} />, $portal_root)
+        : null}
+    </Context.Provider>
+  )
+}
+
+export function useModalContext() {
+  const value = useContext(Context)
+
+  if (value == null) {
+    throw new Error('ModalContext 안에서 사용해주세요')
+  }
+
+  return value
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import { ModalContext } from './contexts/ModalContext'
 import reportWebVitals from './reportWebVitals'
 
 import './scss/global.scss'
@@ -8,7 +9,9 @@ import './scss/global.scss'
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
   <React.StrictMode>
-    <App />
+    <ModalContext>
+      <App />
+    </ModalContext>
   </React.StrictMode>,
 )
 

--- a/t
+++ b/t
@@ -1,0 +1,100 @@
+warning: in the working copy of 'public/index.html', LF will be replaced by CRLF the next time Git touches it
+[1mdiff --git a/public/index.html b/public/index.html[m
+[1mindex aa069f2..fd8322d 100644[m
+[1m--- a/public/index.html[m
+[1m+++ b/public/index.html[m
+[36m@@ -29,6 +29,7 @@[m
+   <body>[m
+     <noscript>You need to enable JavaScript to run this app.</noscript>[m
+     <div id="root"></div>[m
+[32m+[m[32m    <div id="root-portal"></div>[m
+     <!--[m
+       This HTML file is a template.[m
+       If you open it directly in the browser, you will see an empty page.[m
+[1mdiff --git a/src/App.tsx b/src/App.tsx[m
+[1mindex 4bfc592..3157efe 100644[m
+[1m--- a/src/App.tsx[m
+[1m+++ b/src/App.tsx[m
+[36m@@ -15,6 +15,8 @@[m [mimport Calendar from '@components/sections/Calendar'[m
+ import Map from '@components/sections/Map'[m
+ import Contact from '@components/sections/Contact'[m
+ import Share from '@components/sections/Share'[m
+[32m+[m[32mimport Modal from '@shared/Modal'[m
+[32m+[m[32mimport AttendCountModal from './components/AttendCountModal'[m
+ [m
+ const cx = classNames.bind(styles)[m
+ [m
+[36m@@ -83,9 +85,10 @@[m [mfunction App() {[m
+       <Invitation message={invitation} />[m
+       <ImageGallery images={galleryImages} />[m
+       <Calendar date={date} />[m
+[31m-      <Map location={location} />[m
+[32m+[m[32m      {/* <Map location={location} /> */}[m
+       <Contact groom={groom} bride={bride} />[m
+       <Share gromeName={groom.name} brideName={bride.name} date={date} />[m
+[32m+[m[32m      <AttendCountModal wedding={wedding} />[m
+     </div>[m
+   )[m
+ }[m
+[1mdiff --git a/src/components/shared/Modal.tsx b/src/components/shared/Modal.tsx[m
+[1mindex 09f998b..225dd32 100644[m
+[1m--- a/src/components/shared/Modal.tsx[m
+[1m+++ b/src/components/shared/Modal.tsx[m
+[36m@@ -6,7 +6,7 @@[m [mconst cx = classNames.bind(styles)[m
+ [m
+ interface ModalProps {[m
+   open: boolean[m
+[31m-  title: string[m
+[32m+[m[32m  title?: string[m
+   body: React.ReactNode[m
+   rightButtonLabel?: string[m
+   onRightButtonClick: () => void[m
+[36m@@ -18,8 +18,8 @@[m [mexport default function Modal({[m
+   open,[m
+   title,[m
+   body,[m
+[31m-  rightButtonLabel = '닫기',[m
+[31m-  leftButtonLabel = '확인',[m
+[32m+[m[32m  rightButtonLabel = '확인',[m
+[32m+[m[32m  leftButtonLabel = '닫기',[m
+   onRightButtonClick,[m
+   onLeftButtonClick,[m
+ }: ModalProps) {[m
+[1mdiff --git a/src/index.tsx b/src/index.tsx[m
+[1mindex fd663d6..03ad8a0 100644[m
+[1m--- a/src/index.tsx[m
+[1m+++ b/src/index.tsx[m
+[36m@@ -1,6 +1,7 @@[m
+ import React from 'react'[m
+ import ReactDOM from 'react-dom/client'[m
+ import App from './App'[m
+[32m+[m[32mimport { ModalContext } from './contexts/ModalContext'[m
+ import reportWebVitals from './reportWebVitals'[m
+ [m
+ import './scss/global.scss'[m
+[36m@@ -8,7 +9,9 @@[m [mimport './scss/global.scss'[m
+ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)[m
+ root.render([m
+   <React.StrictMode>[m
+[31m-    <App />[m
+[32m+[m[32m    <ModalContext>[m
+[32m+[m[32m      <App />[m
+[32m+[m[32m    </ModalContext>[m
+   </React.StrictMode>,[m
+ )[m
+ [m
+[1mdiff --git a/tsconfig.paths.json b/tsconfig.paths.json[m
+[1mindex e31455e..54159db 100644[m
+[1m--- a/tsconfig.paths.json[m
+[1m+++ b/tsconfig.paths.json[m
+[36m@@ -6,7 +6,8 @@[m
+             "@components/*": ["src/components/*"],[m
+             "@shared/*": ["src/components/shared/*"],[m
+             "@models/*": ["src/models/*"],[m
+[31m-            "@scss/*": ["src/scss/*"][m
+[32m+[m[32m            "@scss/*": ["src/scss/*"],[m
+[32m+[m[32m            "@contexts/*": ["src/contexts/*"][m
+         }[m
+     }[m
+ }[m
+\ No newline at end of file[m

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -6,7 +6,8 @@
             "@components/*": ["src/components/*"],
             "@shared/*": ["src/components/shared/*"],
             "@models/*": ["src/models/*"],
-            "@scss/*": ["src/scss/*"]
+            "@scss/*": ["src/scss/*"],
+            "@contexts/*": ["src/contexts/*"]
         }
     }
 }


### PR DESCRIPTION
- modal component를 react portal을 이용하여 parent를 변경
  - 화면 정중앙 띄우는 용도
- modal component를 context api를 이용하도록 변경하여 open함수에 참석자 관련 api 추가
- 참석자를 추가한 경우 local storage 저장, db에 업데이트 기능 추가